### PR TITLE
Changed py.test --> pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 coala-bears==0.2.1
-py.test
+pytest


### PR DESCRIPTION
Tried to set up development environment got this error
    ValueError: please use 'pytest' pypi package instead of 'py.test'

fixed 
